### PR TITLE
internal/proxy: port script from Go Cloud to create module proxy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,5 +45,5 @@ script:
 
 env:
   global:
-  - GOPROXY=https://storage.googleapis.com/go-cloud-modules/
+  - GOPROXY=https://storage.googleapis.com/wire-modules/
   - GO111MODULE=on

--- a/internal/proxy/README.md
+++ b/internal/proxy/README.md
@@ -1,0 +1,64 @@
+# Wire module proxy
+
+The Travis build for Wire uses a [Go module proxy][] for dependencies, for
+efficiency and reliability, and to enforce that all of our dependencies meet our
+license requirements.
+
+The proxy is set
+[here](https://github.com/google/wire/blob/master/.travis.yml#L48).
+
+[Go module proxy]: https://research.swtch.com/vgo-module
+
+## Updating the GCS bucket
+
+When you add a new dependency, the Travis build will fail. To add the new
+dependency to the proxy:
+
+1.  Ensure that the new dependency is covered under one of the `notice`,
+    `permissive`, or `unencumbered` licences under the categories defined by
+    [Google Open Source](https://opensource.google.com/docs/thirdparty/licenses/).
+2.  Gather the new set of dependencies and sync them to the GCS bucket.
+
+```bash
+# This approach was suggested by:
+# https://github.com/go-modules-by-example/index/tree/master/012_modvendor
+
+# Create a temporary directory where we'll create a module download cache.
+tgp="$(mktemp -d)"
+
+# Copy current module cache into temporary directory as basis.
+# Periodically, someone on the project should go through this process without
+# running this step to prune unused dependencies.
+mkdir -p "$tgp/pkg/mod/cache/download"
+gsutil -m rsync -r gs://wire-modules "$tgp/pkg/mod/cache/download"
+
+# Run this command in the master branch.
+# It runs "go mod download" in every module that we have in our repo,
+# filling the cache with all of the module dependencies we need.
+./internal/proxy/makeproxy.sh "$tgp"
+
+# Run the above command again in your branch that's adding a new dependency,
+# to ensure the cache has any new dependencies.
+
+# Move the temporary cache to modvendor/.
+rm -rf modvendor
+cp -rp "$tgp/pkg/mod/cache/download/" modvendor
+
+# Clean up the temporary cache.
+GOPATH="$tgp" go clean -modcache
+rm -rf "$tgp"
+unset tgp
+
+# Synchronize modvendor to the proxy.
+
+# -n: preview only
+# -r: recurse directories
+# -c: compare checksums not write times
+# -d: delete remote files that aren't present locally
+gsutil rsync -n -r -c -d modvendor gs://wire-modules
+# If the set of packages being added and removed looks good,
+# repeat without the -n.
+
+# Once you are done...
+rm -rf modvendor
+```

--- a/internal/proxy/makeproxy.sh
+++ b/internal/proxy/makeproxy.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# Copyright 2018 The Wire Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This script downloads and arranges packages in a structure for a
+# Wire proxy.
+
+# https://coderwall.com/p/fkfaqq/safer-bash-scripts-with-set-euxo-pipefail
+set -euxo pipefail
+
+if [[ $# -ne 1 ]]; then
+  echo "usage: makeproxy.sh <dir>" 1>&2
+  exit 64
+fi
+
+export GOPATH="$1"
+root="$( cd "$( dirname "${BASH_SOURCE[0]}" )/../.." >/dev/null && pwd )"
+cd "$root"
+go mod download


### PR DESCRIPTION
I have created `gs://wire-modules` to store the Wire dependencies. I ran the script in this commit to populate the contents of the GCS bucket and am updating Travis to point to the new proxy.

Fixes #81