### PR TITLE
.contributebot: disable issue title check

### DIFF
--- a/.contributebot
+++ b/.contributebot
@@ -1,0 +1,3 @@
+{
+  "issue_title_pattern": "^.*$"
+}


### PR DESCRIPTION
All issues are assumed to be about Wire, so there's no need to include
the package name.

Updates #82