### PR TITLE
internal/wire/testdata/PkgImport: add back duplicate import

### DIFF
--- a/internal/wire/testdata/PkgImport/foo/wire.go
+++ b/internal/wire/testdata/PkgImport/foo/wire.go
@@ -17,7 +17,7 @@
 package main
 
 import (
-	_ "example.com/anon1"
+	_ "example.com/anon1" // intentionally duplicated
 	_ "example.com/anon2"
 	"github.com/google/wire"
 )


### PR DESCRIPTION
This got removed as part of my gofmt run on #101.

/cc @doodlesbykumbi