### PR TITLE
all: update version of tools used in go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,5 +3,5 @@ module github.com/google/wire
 require (
 	github.com/google/go-cmp v0.2.0
 	github.com/pmezard/go-difflib v1.0.0
-	golang.org/x/tools v0.0.0-20181017214349-06f26fdaaa28
+	golang.org/x/tools v0.0.0-20190205201329-379209517ffe
 )

--- a/go.sum
+++ b/go.sum
@@ -4,3 +4,5 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 golang.org/x/tools v0.0.0-20181017214349-06f26fdaaa28 h1:vnbqcYKfOxPnXXUlBo7t+R4pVIh0wInyOSNxih1S9Dc=
 golang.org/x/tools v0.0.0-20181017214349-06f26fdaaa28/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
+golang.org/x/tools v0.0.0-20190205201329-379209517ffe h1:wgpl8ZFbbyCTwUEyUPYafSzqRqUUGAuN9JSXU9iBjts=
+golang.org/x/tools v0.0.0-20190205201329-379209517ffe/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=


### PR DESCRIPTION
This pulls in a version of go/packages that uses the latest
gopackagesdriver protocol.
