### PR TITLE
wire/tests: Add a test that defines a ProviderSet with a binding but no corresponding concrete type

### DIFF
--- a/internal/wire/testdata/ProviderSetBindingMissingConcreteType/foo/foo.go
+++ b/internal/wire/testdata/ProviderSetBindingMissingConcreteType/foo/foo.go
@@ -1,0 +1,49 @@
+// Copyright 2019 The Wire Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"fmt"
+
+	"github.com/google/wire"
+)
+
+func main() {
+	fmt.Println(injectFoo())
+}
+
+type fooer interface {
+	Do() string
+}
+
+type foo struct{}
+
+func (f *foo) Do() string {
+	return "did foo"
+}
+
+func newFoo() *foo {
+	return &foo{}
+}
+
+var (
+	setA = wire.NewSet(newFoo)
+	// This set is invalid because it has a wire.Bind but no matching provider.
+	// From the user guide:
+	// Any set that includes an interface binding must also have a provider in
+	// the same set that provides the concrete type.
+	setB = wire.NewSet(wire.Bind(new(fooer), new(foo)))
+	setC = wire.NewSet(setA, setB)
+)

--- a/internal/wire/testdata/ProviderSetBindingMissingConcreteType/foo/wire.go
+++ b/internal/wire/testdata/ProviderSetBindingMissingConcreteType/foo/wire.go
@@ -1,0 +1,26 @@
+// Copyright 2019 The Wire Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//+build wireinject
+
+package main
+
+import (
+	"github.com/google/wire"
+)
+
+func injectFoo() *foo {
+	wire.Build(setC)
+	return nil
+}

--- a/internal/wire/testdata/ProviderSetBindingMissingConcreteType/pkg
+++ b/internal/wire/testdata/ProviderSetBindingMissingConcreteType/pkg
@@ -1,0 +1,1 @@
+example.com/foo

--- a/internal/wire/testdata/ProviderSetBindingMissingConcreteType/want/wire_errs.txt
+++ b/internal/wire/testdata/ProviderSetBindingMissingConcreteType/want/wire_errs.txt
@@ -1,0 +1,1 @@
+example.com/foo/foo.go:x:y: no binding for *example.com/foo.foo


### PR DESCRIPTION
The test fails as expected, but the error message is poor and should be improved.

Updates #113 .