### PR TITLE
guide: clarify interface binding examples

### DIFF
--- a/docs/guide.md
+++ b/docs/guide.md
@@ -195,24 +195,31 @@ provider set:
 
 ```go
 type Fooer interface {
-    Foo() string
+    Foo() Baz
 }
 
 type Bar string
 
-func (b *Bar) Foo() string {
-    return string(*b)
+func (b *Bar) Foo() Baz {
+    return Baz(*b)
 }
 
-func ProvideBar() *Bar {
+func provideBar() *Bar {
     b := new(Bar)
     *b = "Hello, World!"
     return b
 }
 
-var BarFooer = wire.NewSet(
-    ProvideBar,
-    wire.Bind(new(Fooer), new(Bar)))
+type Baz string
+
+func provideBaz(f Fooer) Baz {
+    return f.Foo()
+}
+
+var Set = wire.NewSet(
+    provideBar,
+    wire.Bind((*Fooer)(nil), (*Bar)(nil)),
+    provideBaz)
 ```
 
 The first argument to `wire.Bind` is a pointer to a value of the desired

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -195,31 +195,31 @@ provider set:
 
 ```go
 type Fooer interface {
-    Foo() Baz
+    Foo() string
 }
 
-type Bar string
+type MyFooer string
 
-func (b *Bar) Foo() Baz {
-    return Baz(*b)
+func (b *MyFooer) Foo() string {
+    return string(*b)
 }
 
-func provideBar() *Bar {
-    b := new(Bar)
+func provideMyFooer() *MyFooer {
+    b := new(MyFooer)
     *b = "Hello, World!"
     return b
 }
 
-type Baz string
+type Bar string
 
-func provideBaz(f Fooer) Baz {
+func provideBar(f Fooer) string {
     return f.Foo()
 }
 
 var Set = wire.NewSet(
-    provideBar,
-    wire.Bind((*Fooer)(nil), (*Bar)(nil)),
-    provideBaz)
+    provideMyFooer,
+    wire.Bind((*Fooer)(nil), (*MyFooer)(nil)),
+    provideBar)
 ```
 
 The first argument to `wire.Bind` is a pointer to a value of the desired

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -213,6 +213,7 @@ func provideMyFooer() *MyFooer {
 type Bar string
 
 func provideBar(f Fooer) string {
+    // f will be a *MyFooer.
     return f.Foo()
 }
 


### PR DESCRIPTION
Add a provider that takes in a `Fooer` so that it becomes more clear.

Updates #116 