### PR TITLE
wire: support using '-' tag to prevent filling struct fields

### DIFF
--- a/internal/wire/analyze.go
+++ b/internal/wire/analyze.go
@@ -276,7 +276,7 @@ func verifyArgsUsed(set *ProviderSet, used []*providerSetSrc) []error {
 			}
 		}
 		if !found {
-			errs = append(errs, fmt.Errorf("unused provider %q", p.Pkg.Name() + "." + p.Name))
+			errs = append(errs, fmt.Errorf("unused provider %q", p.Pkg.Name()+"."+p.Name))
 		}
 	}
 	for _, v := range set.Values {

--- a/internal/wire/parse.go
+++ b/internal/wire/parse.go
@@ -744,6 +744,8 @@ func funcOutput(sig *types.Signature) (outputSignature, error) {
 // It produces pointer and non-pointer variants via two values in Out.
 //
 // This is a copy of the old processStructProvider, which is deprecated now.
+// It will not support any new feature introduced after v0.2. Please use the new
+// wire.Struct syntax for those.
 func processStructLiteralProvider(fset *token.FileSet, typeName *types.TypeName) (*Provider, []error) {
 	out := typeName.Type()
 	st, ok := out.Underlying().(*types.Struct)
@@ -813,7 +815,6 @@ func processStructProvider(fset *token.FileSet, info *types.Info, call *ast.Call
 		Out:      []types.Type{structPtr.Elem(), structPtr},
 	}
 	if allFields(call) {
-		provider.Args = make([]ProviderInput, 0)
 		for i := 0; i < st.NumFields(); i++ {
 			if isPrevented(st, i) {
 				continue
@@ -862,6 +863,7 @@ func allFields(call *ast.CallExpr) bool {
 // isPrevented checks whether field i is prevented by tag "-".
 // Since this is the only tag used by wire, we can do string comparison
 // without using reflect.
+// TODO(#179): parse the wire tag more robustly.
 func isPrevented(st *types.Struct, i int) bool {
 	return strings.Contains(st.Tag(i), `wire:"-"`)
 }

--- a/internal/wire/testdata/StructWithPreventTag/foo/foo.go
+++ b/internal/wire/testdata/StructWithPreventTag/foo/foo.go
@@ -22,35 +22,27 @@ import (
 )
 
 func main() {
-	fb := injectFooBar()
 	pfb := injectPartFooBar()
-	fmt.Println(fb.Foo, fb.Bar)
-	fmt.Println(pfb.Foo, pfb.Bar)
+	fmt.Println(pfb.Foo)
 }
 
 type Foo int
-type Bar int
 
 type FooBar struct {
 	mu  sync.Mutex `wire:"-"`
 	Foo Foo
-	Bar Bar
 }
 
 func provideFoo() Foo {
-	return 41
+	return 42
 }
 
-func provideBar() Bar {
-	return 1
+func provideMutex() sync.Mutex {
+	return sync.Mutex{}
 }
 
-var Set = wire.NewSet(
-	wire.Struct(new(FooBar), "*"),
-	provideFoo,
-	provideBar)
-
-var PartSet = wire.NewSet(
-	wire.Struct(new(FooBar), "Foo"),
+var ProhibitSet = wire.NewSet(
+	wire.Struct(new(FooBar), "mu", "Foo"),
+	provideMutex,
 	provideFoo,
 )

--- a/internal/wire/testdata/StructWithPreventTag/foo/wire.go
+++ b/internal/wire/testdata/StructWithPreventTag/foo/wire.go
@@ -12,45 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//+build wireinject
+
 package main
 
 import (
-	"fmt"
-	"sync"
-
 	"github.com/google/wire"
 )
 
-func main() {
-	fb := injectFooBar()
-	pfb := injectPartFooBar()
-	fmt.Println(fb.Foo, fb.Bar)
-	fmt.Println(pfb.Foo, pfb.Bar)
+func injectPartFooBar() FooBar {
+	wire.Build(ProhibitSet)
+	return FooBar{}
 }
-
-type Foo int
-type Bar int
-
-type FooBar struct {
-	mu  sync.Mutex `wire:"-"`
-	Foo Foo
-	Bar Bar
-}
-
-func provideFoo() Foo {
-	return 41
-}
-
-func provideBar() Bar {
-	return 1
-}
-
-var Set = wire.NewSet(
-	wire.Struct(new(FooBar), "*"),
-	provideFoo,
-	provideBar)
-
-var PartSet = wire.NewSet(
-	wire.Struct(new(FooBar), "Foo"),
-	provideFoo,
-)

--- a/internal/wire/testdata/StructWithPreventTag/pkg
+++ b/internal/wire/testdata/StructWithPreventTag/pkg
@@ -1,0 +1,1 @@
+example.com/foo

--- a/internal/wire/testdata/StructWithPreventTag/want/wire_errs.txt
+++ b/internal/wire/testdata/StructWithPreventTag/want/wire_errs.txt
@@ -1,0 +1,1 @@
+example.com/foo/foo.go:x:y: "mu" is prevented from injecting by wire

--- a/internal/wire/testdata/UnusedProviders/foo/foo.go
+++ b/internal/wire/testdata/UnusedProviders/foo/foo.go
@@ -21,7 +21,7 @@ import (
 )
 
 func main() {
-	fmt.Println(injectBar())
+	fmt.Println(injectFooBar())
 }
 
 type Foo int
@@ -30,6 +30,12 @@ type Unused int
 type UnusedInSet int
 type OneOfTwo int
 type TwoOfTwo int
+
+type FooBar struct {
+	MyFoo    *Foo
+	MyBar    Bar
+	MyUnused Unused
+}
 
 var (
 	unusedSet        = wire.NewSet(provideUnusedInSet)

--- a/internal/wire/testdata/UnusedProviders/foo/wire.go
+++ b/internal/wire/testdata/UnusedProviders/foo/wire.go
@@ -20,16 +20,17 @@ import (
 	"github.com/google/wire"
 )
 
-func injectBar() Bar {
+func injectFooBar() FooBar {
 	wire.Build(
 		provideFoo,                       // needed as input for provideBar
-		provideBar,                       // needed for Bar
+		provideBar,                       // needed for FooBar
 		partiallyUsedSet,                 // 1/2 providers in the set are needed
 		provideUnused,                    // not needed -> error
 		wire.Value("unused"),             // not needed -> error
 		unusedSet,                        // nothing in set is needed -> error
 		wire.Bind(new(Fooer), new(*Foo)), // binding to Fooer is not needed -> error
 		wire.FieldsOf(new(S), "Cfg"),     // S.Cfg not needed -> error
+		wire.Struct(new(FooBar), "MyFoo", "MyBar"), // needed for FooBar
 	)
-	return 0
+	return FooBar{}
 }

--- a/internal/wire/testdata/UnusedProviders/want/wire_errs.txt
+++ b/internal/wire/testdata/UnusedProviders/want/wire_errs.txt
@@ -1,9 +1,9 @@
-example.com/foo/wire.go:x:y: inject injectBar: unused provider set "unusedSet"
+example.com/foo/wire.go:x:y: inject injectFooBar: unused provider set "unusedSet"
 
-example.com/foo/wire.go:x:y: inject injectBar: unused provider "main.provideUnused"
+example.com/foo/wire.go:x:y: inject injectFooBar: unused provider "main.provideUnused"
 
-example.com/foo/wire.go:x:y: inject injectBar: unused value of type string
+example.com/foo/wire.go:x:y: inject injectFooBar: unused value of type string
 
-example.com/foo/wire.go:x:y: inject injectBar: unused interface binding to type example.com/foo.Fooer
+example.com/foo/wire.go:x:y: inject injectFooBar: unused interface binding to type example.com/foo.Fooer
 
-example.com/foo/wire.go:x:y: inject injectBar: unused field "example.com/foo.S".Cfg
+example.com/foo/wire.go:x:y: inject injectFooBar: unused field "example.com/foo.S".Cfg


### PR DESCRIPTION
Updates #110 

1. When using "*", wire will omit the fields with "-" tag.
1. When specifying a prevented field, wire will give an error.