### PR TITLE
wire: wire.FieldsOf should not provide pointer to field type for non-pointer structs

### DIFF
--- a/docs/guide.md
+++ b/docs/guide.md
@@ -423,7 +423,8 @@ func injectedMessage() string {
 ```
 
 You can add as many field names to a `wire.FieldsOf` function as you like.
-For a given field type `T`, `FieldsOf` provides both `T` and `*T`.
+For a given field type `T`, `FieldsOf` provides at least `T`; if the struct
+argument is a pointer to a struct, then `FieldsOf` also provides `*T`.
 
 ### Cleanup functions
 

--- a/internal/wire/analyze.go
+++ b/internal/wire/analyze.go
@@ -232,9 +232,9 @@ dfs:
 			}
 			// Use args[0] to store the position of the parent struct.
 			args := []int{v.(int)}
-			// len(f.Out) is always 2; if curr.t is the 2nd one, then the call must
+			// If f.Out has 2 elements and curr.t is the 2nd one, then the call must
 			// provide a pointer to the field.
-			ptrToField := types.Identical(curr.t, f.Out[1])
+			ptrToField := len(f.Out) == 2 && types.Identical(curr.t, f.Out[1])
 			calls = append(calls, call{
 				kind:       selectorExpr,
 				pkg:        f.Pkg,

--- a/internal/wire/testdata/FieldsOfStruct/foo/wire.go
+++ b/internal/wire/testdata/FieldsOfStruct/foo/wire.go
@@ -26,10 +26,3 @@ func injectedMessage() string {
 		wire.FieldsOf(new(S), "Foo"))
 	return ""
 }
-
-func injectedMessagePtr() *string {
-	wire.Build(
-		provideS,
-		wire.FieldsOf(new(S), "Foo"))
-	return nil
-}

--- a/internal/wire/testdata/FieldsOfStruct/want/program_out.txt
+++ b/internal/wire/testdata/FieldsOfStruct/want/program_out.txt
@@ -1,2 +1,1 @@
 Hello, World!
-pointer to Hello, World!

--- a/internal/wire/testdata/FieldsOfStruct/want/wire_gen.go
+++ b/internal/wire/testdata/FieldsOfStruct/want/wire_gen.go
@@ -12,9 +12,3 @@ func injectedMessage() string {
 	string2 := s.Foo
 	return string2
 }
-
-func injectedMessagePtr() *string {
-	s := provideS()
-	string2 := &s.Foo
-	return string2
-}

--- a/internal/wire/testdata/FieldsOfStructDoNotProvidePtrToField/foo/foo.go
+++ b/internal/wire/testdata/FieldsOfStructDoNotProvidePtrToField/foo/foo.go
@@ -25,5 +25,5 @@ func provideS() S {
 }
 
 func main() {
-	fmt.Println(injectedMessage())
+	fmt.Println("pointer to " + *injectedMessagePtr())
 }

--- a/internal/wire/testdata/FieldsOfStructDoNotProvidePtrToField/foo/foo.go
+++ b/internal/wire/testdata/FieldsOfStructDoNotProvidePtrToField/foo/foo.go
@@ -1,4 +1,4 @@
-// Copyright 2018 The Wire Authors
+// Copyright 2019 The Wire Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/wire/testdata/FieldsOfStructDoNotProvidePtrToField/foo/wire.go
+++ b/internal/wire/testdata/FieldsOfStructDoNotProvidePtrToField/foo/wire.go
@@ -12,18 +12,21 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//+build wireinject
+
 package main
 
-import "fmt"
+import (
+	"github.com/google/wire"
+)
 
-type S struct {
-	Foo string
-}
-
-func provideS() S {
-	return S{Foo: "Hello, World!"}
-}
-
-func main() {
-	fmt.Println(injectedMessage())
+func injectedMessagePtr() *string {
+	// This shouldn't work; FieldsOf provides a pointer to the
+	// field only when the struct type is a pointer to a struct.
+	// See FieldsOfStructPointer for a working example using
+	// a pointer to a struct.
+	wire.Build(
+		provideS,
+		wire.FieldsOf(new(S), "Foo"))
+	return nil
 }

--- a/internal/wire/testdata/FieldsOfStructDoNotProvidePtrToField/foo/wire.go
+++ b/internal/wire/testdata/FieldsOfStructDoNotProvidePtrToField/foo/wire.go
@@ -1,4 +1,4 @@
-// Copyright 2018 The Wire Authors
+// Copyright 2019 The Wire Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/wire/testdata/FieldsOfStructDoNotProvidePtrToField/pkg
+++ b/internal/wire/testdata/FieldsOfStructDoNotProvidePtrToField/pkg
@@ -1,0 +1,1 @@
+example.com/foo

--- a/internal/wire/testdata/FieldsOfStructDoNotProvidePtrToField/want/wire_errs.txt
+++ b/internal/wire/testdata/FieldsOfStructDoNotProvidePtrToField/want/wire_errs.txt
@@ -1,0 +1,1 @@
+example.com/foo/wire.go:x:y: inject injectedMessagePtr: no provider found for *string, output of injector

--- a/internal/wire/testdata/FieldsOfStructPointer/foo/foo.go
+++ b/internal/wire/testdata/FieldsOfStructPointer/foo/foo.go
@@ -26,4 +26,5 @@ func provideS() *S {
 
 func main() {
 	fmt.Println(injectedMessage())
+	fmt.Println("pointer to " + *injectedMessagePtr())
 }

--- a/internal/wire/testdata/FieldsOfStructPointer/foo/wire.go
+++ b/internal/wire/testdata/FieldsOfStructPointer/foo/wire.go
@@ -26,3 +26,10 @@ func injectedMessage() string {
 		wire.FieldsOf(new(*S), "Foo"))
 	return ""
 }
+
+func injectedMessagePtr() *string {
+	wire.Build(
+		provideS,
+		wire.FieldsOf(new(*S), "Foo"))
+	return nil
+}

--- a/internal/wire/testdata/FieldsOfStructPointer/want/program_out.txt
+++ b/internal/wire/testdata/FieldsOfStructPointer/want/program_out.txt
@@ -1,1 +1,2 @@
 Hello, World!
+pointer to Hello, World!

--- a/internal/wire/testdata/FieldsOfStructPointer/want/wire_gen.go
+++ b/internal/wire/testdata/FieldsOfStructPointer/want/wire_gen.go
@@ -12,3 +12,9 @@ func injectedMessage() string {
 	string2 := s.Foo
 	return string2
 }
+
+func injectedMessagePtr() *string {
+	s := provideS()
+	string2 := &s.Foo
+	return string2
+}

--- a/wire.go
+++ b/wire.go
@@ -173,11 +173,11 @@ type StructFields struct{}
 // to provide the types of those fields. The structType argument must be a
 // pointer to the struct or a pointer to a pointer to the struct it wishes to reference.
 //
-// The following example would provide *Foo and *Bar using S.MyFoo and S.MyBar respectively:
+// The following example would provide Foo and Bar using S.MyFoo and S.MyBar respectively:
 //
 //  type S struct {
-//  	MyFoo *Foo
-//  	MyBar *Bar
+//  	MyFoo Foo
+//  	MyBar Bar
 //  }
 //
 //  func NewStruct() S { /* ... */ }
@@ -189,7 +189,7 @@ type StructFields struct{}
 //  var Set = wire.NewSet(wire.FieldsOf(new(*S), "MyFoo", "MyBar"))
 //
 //  If the structType argument is a pointer to a pointer to a struct, then FieldsOf
-//  additionally provides a pointer to each field type (e.g., **Foo and **Bar in the
+//  additionally provides a pointer to each field type (e.g., *Foo and *Bar in the
 //  example above).
 func FieldsOf(structType interface{}, fieldNames ...string) StructFields {
 	return StructFields{}

--- a/wire.go
+++ b/wire.go
@@ -187,6 +187,10 @@ type StructFields struct{}
 //
 //  func NewStruct() *S { /* ... */ }
 //  var Set = wire.NewSet(wire.FieldsOf(new(*S), "MyFoo", "MyBar"))
+//
+//  If the structType argument is a pointer to a pointer to a struct, then FieldsOf
+//  additionally provides a pointer to each field type (e.g., **Foo and **Bar in the
+//  example above).
 func FieldsOf(structType interface{}, fieldNames ...string) StructFields {
 	return StructFields{}
 }


### PR DESCRIPTION
@zombiezen pointed out (hah!) that `FieldsOf` should not provide a pointer to field types in cases where the struct itself is not a pointer; the struct is then a temporary variable.

I moved the previously-working "pointer to field type" test from `FieldsOfStruct` to `FieldsOfStructPointer`, and added a new non-working testcase attempting to provide a ptr-to-field from a non-pointer struct (expected to fail).

Fixes #208.