### PR TITLE
cmd: Allowing to change the output file name from wire_gen.go to other

### DIFF
--- a/cmd/wire/main.go
+++ b/cmd/wire/main.go
@@ -116,7 +116,7 @@ func (*genCmd) Usage() string {
 }
 func (cmd *genCmd) SetFlags(f *flag.FlagSet) {
 	f.StringVar(&cmd.headerFile, "header_file", "", "path to file to insert as a header in wire_gen.go")
-	f.StringVar(&cmd.prefixFileName, "prefix", "", "prefix to the output files concat with 'wire_gen.go' suffix.")
+	f.StringVar(&cmd.prefixFileName, "output_file_prefix", "", "string to prepend to output file names.")
 }
 
 func (cmd *genCmd) Execute(ctx context.Context, f *flag.FlagSet, args ...interface{}) subcommands.ExitStatus {

--- a/cmd/wire/main.go
+++ b/cmd/wire/main.go
@@ -98,7 +98,8 @@ func newGenerateOptions(headerFile string) (*wire.GenerateOptions, error) {
 }
 
 type genCmd struct {
-	headerFile string
+	headerFile     string
+	outputFileName string
 }
 
 func (*genCmd) Name() string { return "gen" }
@@ -115,6 +116,7 @@ func (*genCmd) Usage() string {
 }
 func (cmd *genCmd) SetFlags(f *flag.FlagSet) {
 	f.StringVar(&cmd.headerFile, "header_file", "", "path to file to insert as a header in wire_gen.go")
+	f.StringVar(&cmd.outputFileName, "output_file", "", "change the output default file 'wire_gen.go' for a custom name.")
 }
 
 func (cmd *genCmd) Execute(ctx context.Context, f *flag.FlagSet, args ...interface{}) subcommands.ExitStatus {
@@ -128,6 +130,11 @@ func (cmd *genCmd) Execute(ctx context.Context, f *flag.FlagSet, args ...interfa
 		log.Println(err)
 		return subcommands.ExitFailure
 	}
+	opts.OutputFile = "wire_gen.go"
+	if cmd.outputFileName != "" {
+		opts.OutputFile = cmd.outputFileName
+	}
+
 	outs, errs := wire.Generate(ctx, wd, os.Environ(), packages(f), opts)
 	if len(errs) > 0 {
 		logErrors(errs)
@@ -200,6 +207,7 @@ func (cmd *diffCmd) Execute(ctx context.Context, f *flag.FlagSet, args ...interf
 		log.Println(err)
 		return subcommands.ExitFailure
 	}
+
 	outs, errs := wire.Generate(ctx, wd, os.Environ(), packages(f), opts)
 	if len(errs) > 0 {
 		logErrors(errs)

--- a/cmd/wire/main.go
+++ b/cmd/wire/main.go
@@ -99,7 +99,7 @@ func newGenerateOptions(headerFile string) (*wire.GenerateOptions, error) {
 
 type genCmd struct {
 	headerFile     string
-	outputFileName string
+	prefixFileName string
 }
 
 func (*genCmd) Name() string { return "gen" }
@@ -116,7 +116,7 @@ func (*genCmd) Usage() string {
 }
 func (cmd *genCmd) SetFlags(f *flag.FlagSet) {
 	f.StringVar(&cmd.headerFile, "header_file", "", "path to file to insert as a header in wire_gen.go")
-	f.StringVar(&cmd.outputFileName, "output_file", "", "change the output default file 'wire_gen.go' for a custom name.")
+	f.StringVar(&cmd.prefixFileName, "prefix", "", "prefix to the output files concat with 'wire_gen.go' suffix.")
 }
 
 func (cmd *genCmd) Execute(ctx context.Context, f *flag.FlagSet, args ...interface{}) subcommands.ExitStatus {
@@ -130,10 +130,8 @@ func (cmd *genCmd) Execute(ctx context.Context, f *flag.FlagSet, args ...interfa
 		log.Println(err)
 		return subcommands.ExitFailure
 	}
-	opts.OutputFile = "wire_gen.go"
-	if cmd.outputFileName != "" {
-		opts.OutputFile = cmd.outputFileName
-	}
+
+	opts.PrefixOutputFile = cmd.prefixFileName
 
 	outs, errs := wire.Generate(ctx, wd, os.Environ(), packages(f), opts)
 	if len(errs) > 0 {

--- a/internal/wire/wire.go
+++ b/internal/wire/wire.go
@@ -63,7 +63,8 @@ func (gen GenerateResult) Commit() error {
 // GenerateOptions holds options for Generate.
 type GenerateOptions struct {
 	// Header will be inserted at the start of each generated file.
-	Header []byte
+	Header     []byte
+	OutputFile string
 }
 
 // Generate performs dependency injection for the packages that match the given
@@ -94,7 +95,7 @@ func Generate(ctx context.Context, wd string, env []string, patterns []string, o
 			generated[i].Errs = append(generated[i].Errs, err)
 			continue
 		}
-		generated[i].OutputPath = filepath.Join(outDir, "wire_gen.go")
+		generated[i].OutputPath = filepath.Join(outDir, opts.OutputFile)
 		g := newGen(pkg)
 		injectorFiles, errs := generateInjectors(g, pkg)
 		if len(errs) > 0 {

--- a/internal/wire/wire.go
+++ b/internal/wire/wire.go
@@ -63,8 +63,8 @@ func (gen GenerateResult) Commit() error {
 // GenerateOptions holds options for Generate.
 type GenerateOptions struct {
 	// Header will be inserted at the start of each generated file.
-	Header     []byte
-	OutputFile string
+	Header           []byte
+	PrefixOutputFile string
 }
 
 // Generate performs dependency injection for the packages that match the given
@@ -95,7 +95,7 @@ func Generate(ctx context.Context, wd string, env []string, patterns []string, o
 			generated[i].Errs = append(generated[i].Errs, err)
 			continue
 		}
-		generated[i].OutputPath = filepath.Join(outDir, opts.OutputFile)
+		generated[i].OutputPath = filepath.Join(outDir, opts.PrefixOutputFile+"wire_gen.go")
 		g := newGen(pkg)
 		injectorFiles, errs := generateInjectors(g, pkg)
 		if len(errs) > 0 {


### PR DESCRIPTION

Issue #192



