### PR TITLE
internal/wire: mark tests as parallelizable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,10 +45,6 @@ env:
 
 jobs:
   include:
-    - go: "1.11.x"
-      os: linux
-    - go: "1.12.x"
-      os: linux
     - go: "1.13.x"
       os: linux
     - go: "1.13.x"

--- a/internal/wire/wire_test.go
+++ b/internal/wire/wire_test.go
@@ -72,9 +72,7 @@ func TestWire(t *testing.T) {
 	for _, test := range tests {
 		test := test
 		t.Run(test.name, func(t *testing.T) {
-			// TODO(light): These tests should be parallelizable, but this causes
-			// intermittent failures. See https://github.com/google/wire/issues/66
-			// for details.
+			t.Parallel()
 
 			// Materialize a temporary GOPATH directory.
 			gopath, err := ioutil.TempDir("", "wire_test")


### PR DESCRIPTION
Upstream Go issue has been fixed in Go 1.13. I removed older versions of Go from the Travis build matrix.

Fixes #66