### PR TITLE
internal/wire: fix panic in objectCache.processExpr

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -7,6 +7,9 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/net v0.0.0-20190311183353-d8887717615a/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/sys v0.0.0-20190222072716-a9d3bda3a223 h1:DH4skfRX4EBpamg7iV4ZlCpblAHI6s6TDM39bFZumv8=
+golang.org/x/sys v0.0.0-20190222072716-a9d3bda3a223/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/tools v0.0.0-20190422233926-fe54fb35175b h1:NVD8gBK33xpdqCaZVVtd6OFJp+3dxkXuz7+U7KaVN6s=
 golang.org/x/tools v0.0.0-20190422233926-fe54fb35175b/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=

--- a/internal/wire/parse.go
+++ b/internal/wire/parse.go
@@ -534,7 +534,7 @@ func (oc *objectCache) processExpr(info *types.Info, pkgPath string, expr ast.Ex
 		}
 		pkg := fnObj.Pkg()
 		if pkg == nil {
-			return nil, []error{notePosition(exprPos, errors.New("unknown pattern - pkg in fnObj is nil - "+fmt.Sprintf("%s", fnObj)))}
+			return nil, []error{notePosition(exprPos, fmt.Errorf("unknown pattern - pkg in fnObj is nil - %s", fnObj))}
 		}
 		if !isWireImport(pkg.Path()) {
 			return nil, []error{notePosition(exprPos, errors.New("unknown pattern"))}

--- a/internal/wire/parse.go
+++ b/internal/wire/parse.go
@@ -529,7 +529,14 @@ func (oc *objectCache) processExpr(info *types.Info, pkgPath string, expr ast.Ex
 	}
 	if call, ok := expr.(*ast.CallExpr); ok {
 		fnObj := qualifiedIdentObject(info, call.Fun)
-		if fnObj == nil || !isWireImport(fnObj.Pkg().Path()) {
+		if fnObj == nil {
+			return nil, []error{notePosition(exprPos, errors.New("unknown pattern fnObj nil"))}
+		}
+		pkg := fnObj.Pkg()
+		if pkg == nil {
+			return nil, []error{notePosition(exprPos, errors.New("unknown pattern - pkg in fnObj is nil - "+fmt.Sprintf("%s", fnObj)))}
+		}
+		if !isWireImport(pkg.Path()) {
 			return nil, []error{notePosition(exprPos, errors.New("unknown pattern"))}
 		}
 		switch fnObj.Name() {


### PR DESCRIPTION
PR fixes the panic that I've seen with some "edge case" configurations due to using a `nil` object in a compound "chain" of functions calls (unfortunately, didn't save a reproducible sample).
