### PR TITLE
Update installation instruction to remove deprecation warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ For an overview, see the [introductory blog post][].
 Install Wire by running:
 
 ```shell
-go install github.com/google/wire/cmd/wire
+go install github.com/google/wire/cmd/wire@latest
 ```
 
 and ensuring that `$GOPATH/bin` is added to your `$PATH`.


### PR DESCRIPTION
Using `go get` to install an executable produces a deprecation saying that `go install` should be used instead.
