### PR TITLE
Mention go install method in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,12 @@ go get github.com/google/wire/cmd/wire
 
 and ensuring that `$GOPATH/bin` is added to your `$PATH`.
 
+In module mode:
+
+```shell
+go install github.com/google/wire/cmd/wire@v0.5.0
+```
+
 ## Documentation
 
 - [Tutorial][]


### PR DESCRIPTION
Installing via go get in module mode produces the deprecation message:

```
go get: installing executables with 'go get' in module mode is deprecated.
        Use 'go install pkg@version' instead.
        For more information, see https://golang.org/doc/go-get-install-deprecation
        or run 'go help get' or 'go help install'.
```