### PR TITLE
README: fix install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ For an overview, see the [introductory blog post][].
 Install Wire by running:
 
 ```shell
-go get github.com/google/wire/cmd/wire
+go install github.com/google/wire/cmd/wire@latest
 ```
 
 and ensuring that `$GOPATH/bin` is added to your `$PATH`.


### PR DESCRIPTION
go get p has been replaced by go install p@latest.

Fixes #338.