### PR TITLE
Update check_api_change.sh script to reflect default branch name

### DIFF
--- a/internal/check_api_change.sh
+++ b/internal/check_api_change.sh
@@ -25,7 +25,7 @@
 
 set -euo pipefail
 
-UPSTREAM_BRANCH="${GITHUB_BASE_REF:-master}"
+UPSTREAM_BRANCH="${GITHUB_BASE_REF:-main}"
 echo "Checking for incompatible API changes relative to ${UPSTREAM_BRANCH}..."
 
 MASTER_CLONE_DIR="$(mktemp -d)"
@@ -58,7 +58,7 @@ for pkg in $PKGS; do
     continue;
   fi
 
-  # Compute export data for master@HEAD.
+  # Compute export data for main@HEAD.
   (cd "$MASTER_CLONE_DIR"; apidiff -w "$PKGINFO_MASTER" "$pkg")
 
   # Print all changes for posterity.
@@ -79,7 +79,7 @@ fi
 echo "Found breaking API change(s) in: ${incompatible_change_pkgs[*]}."
 
 # Found incompatible changes; see if they were declared as OK via a commit.
-if git cherry -v master | grep -q "BREAKING_CHANGE_OK"; then
+if git cherry -v main | grep -q "BREAKING_CHANGE_OK"; then
   echo "Allowing them due to a commit message with BREAKING_CHANGE_OK.";
   exit 0;
 fi

--- a/internal/runtests.sh
+++ b/internal/runtests.sh
@@ -71,10 +71,9 @@ echo "Ensuring that there are no dependencies not listed in ./internal/alldeps..
 
 # For pull requests, check if there are undeclared incompatible API changes.
 # Skip this if we're already going to fail since it is expensive.
-# CURRENTLY BROKEN
-# if [[ ${result} -eq 0 ]] && [[ ! -z "${GITHUB_HEAD_REF:-x}" ]]; then
-  # echo
-  # ./internal/check_api_change.sh || result=1;
-# fi
+if [[ ${result} -eq 0 ]] && [[ ! -z "${GITHUB_HEAD_REF:-x}" ]]; then
+  echo
+  ./internal/check_api_change.sh || result=1;
+fi
 
 exit $result


### PR DESCRIPTION
To fix the check_api_change.sh build check, change branch name to reflect current default branch of repo.

Building on the [workaround](https://github.com/google/wire/pull/316) for the `check_api_change.sh` script failing, this change would make the script run correctly again, and reinstate its use in the `runtests.sh` build checks.

The underlying problem appeared relate to a change in the default branch name of the repository, from `master` to `main`. Corresponding changes in the script seem to be needed.