### PR TITLE
Update record/replay files for Go 1.18

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        go-version: [1.17.x]
+        go-version: [1.18.x]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Install Go

--- a/internal/wire/testdata/InterfaceBindingNotEnoughArgs/want/wire_errs.txt
+++ b/internal/wire/testdata/InterfaceBindingNotEnoughArgs/want/wire_errs.txt
@@ -1,1 +1,3 @@
 example.com/foo/wire.go:x:y: not enough arguments in call to wire.Bind
+	have (*Fooer)
+	want (interface{}, interface{})

--- a/internal/wire/testdata/InterfaceValueNotEnoughArgs/want/wire_errs.txt
+++ b/internal/wire/testdata/InterfaceValueNotEnoughArgs/want/wire_errs.txt
@@ -1,1 +1,3 @@
 example.com/foo/wire.go:x:y: not enough arguments in call to wire.InterfaceValue
+	have (string)
+	want (interface{}, interface{})


### PR DESCRIPTION
This fixes error message mismatch in InterfaceBindingNotEnoughArgs
and InterfaceValueNotEnoughArgs with Go 1.18.

The Go version in tests.yml GitHub workflow is updated accordingly.

Fixes #355
