### PR TITLE
README: fix install instructions on tutorial

### DIFF
--- a/_tutorial/README.md
+++ b/_tutorial/README.md
@@ -163,7 +163,7 @@ injector complete, we are ready to use the `wire` command line tool.
 Install the tool with:
 
 ``` shell
-go get github.com/google/wire/cmd/wire
+go install github.com/google/wire/cmd/wire@latest
 ```
 
 Then in the same directory with the above code, simply run `wire`. Wire will


### PR DESCRIPTION
Fixes #338 on `_tutorial/README.md`