### PR TITLE
simplify anonymous import handling

### DIFF
--- a/internal/wire/testdata/PkgImport/want/wire_gen.go
+++ b/internal/wire/testdata/PkgImport/want/wire_gen.go
@@ -7,12 +7,9 @@
 package main
 
 import (
-	"example.com/bar"
-)
-
-import (
 	_ "example.com/anon1"
 	_ "example.com/anon2"
+	"example.com/bar"
 )
 
 // Injectors from wire.go:


### PR DESCRIPTION
Anonymous imports were being special-cased and written out separately. They're not that special though, we can just count them as regular imports with the name "_".

This causes them to get grouped together with the other imports like one would expect, and simplifies the generator a bit.

Fixes #358.