### PR TITLE
Export wire.Generate from internal/

### DIFF
--- a/exports.go
+++ b/exports.go
@@ -1,0 +1,8 @@
+package wire
+
+import "github.com/google/wire/internal/wire"
+
+// Generate performs dependency injection for the packages that match the given
+// patterns, return a GenerateResult for each package.
+// See github.com/google/wire/internal/wire.Generate
+var Generate = wire.Generate


### PR DESCRIPTION
This PR explores the idea of allowing wire to be used as a library in addition to its current use as a CLI-only tool.

Currently, all logic to generate the `wire_gen.go` files is locked under the `internal/` directory. While it has its upsides, it blocks users from using wire as a library. It is helpful for framework authors (see the use of wire in [Copper](https://docs.gocopper.dev/the-basics/dependency-injection)) to wrap wire in their own CLIs and still enable dependency injection.

This PR exports the `wire.Generate` method that would allow it to be called by other CLIs to generate the `wire_gen.go` files.