### PR TITLE
Change expected error to fix TestWire/UnexportedStruct

### DIFF
--- a/internal/wire/testdata/UnexportedStruct/want/wire_errs.txt
+++ b/internal/wire/testdata/UnexportedStruct/want/wire_errs.txt
@@ -1,1 +1,1 @@
-example.com/foo/wire.go:x:y: foo not exported by package bar
+example.com/foo/wire.go:x:y: name foo not exported by package bar


### PR DESCRIPTION
Change text of the expected error to fix the current test failer of TestWire/UnexportedStruct.

Fix #412.
