### PR TITLE
refactor: replace deprecated `ioutil` with `io`/`os` equivalents

### DIFF
--- a/internal/wire/testdata/InterfaceValue/foo/foo.go
+++ b/internal/wire/testdata/InterfaceValue/foo/foo.go
@@ -16,11 +16,11 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 )
 
 func main() {
 	r := injectedReader()
-	buf, _ := ioutil.ReadAll(r)
+	buf, _ := io.ReadAll(r) // ioutil.ReadAll --> io.ReadAll
 	fmt.Println(string(buf))
 }

--- a/internal/wire/testdata/ValueIsInterfaceValue/foo/foo.go
+++ b/internal/wire/testdata/ValueIsInterfaceValue/foo/foo.go
@@ -16,12 +16,12 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"strings"
 )
 
 func main() {
 	r := injectedReader(strings.NewReader("hello world"))
-	buf, _ := ioutil.ReadAll(r)
+	buf, _ := io.ReadAll(r) // ioutil.ReadAll --> io.ReadAll
 	fmt.Println(string(buf))
 }

--- a/internal/wire/testdata/ValueIsInterfaceValue/foo/foo.go
+++ b/internal/wire/testdata/ValueIsInterfaceValue/foo/foo.go
@@ -22,6 +22,6 @@ import (
 
 func main() {
 	r := injectedReader(strings.NewReader("hello world"))
-	buf, _ := io.ReadAll(r) // ioutil.ReadAll --> io.ReadAll
+	buf, _ := io.ReadAll(r) 
 	fmt.Println(string(buf))
 }


### PR DESCRIPTION
## Changes
- Replaced all deprecated `ioutil` functions with their `io` or `os` equivalents (supported since Go 1.16+).
- Removed unused `io/ioutil` imports.
- Verified that tests pass (`go test ./...`).

## Motivation
The `ioutil` package is deprecated as of Go 1.16 (see [Go 1.16 release notes](https://golang.org/doc/go1.16#ioutil)). 
This change follows the official migration guidance to modernize the codebase.

## Testing
- All existing tests pass.
- Manually verified the changes in a sample project.

## Notes
This is a backward-compatible change since `io`/`os` equivalents exist in all supported Go versions.