### PR TITLE
Updating the wanted error for testdata/UnexportedStruct

### DIFF
--- a/internal/wire/testdata/UnexportedStruct/want/wire_errs.txt
+++ b/internal/wire/testdata/UnexportedStruct/want/wire_errs.txt
@@ -1,1 +1,1 @@
-example.com/foo/wire.go:x:y: foo not exported by package bar
+example.com/foo/wire.go:x:y: name foo not exported by package bar


### PR DESCRIPTION
adding "name" because runtests.sh reports:
```
        wire_test.go:121: Errors didn't match expected errors from wire_errors.txt:
            {[]string}[0]:
                -: "example.com/foo/wire.go:x:y: name foo not exported by package bar"
                +: "example.com/foo/wire.go:x:y: foo not exported by package bar"
```

Fixes #412 