### PR TITLE
README: add a note that wire is no longer maintained

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,10 @@
 [![Build Status](https://github.com/google/wire/actions/workflows/tests.yml/badge.svg?branch=main)](https://github.com/google/wire/actions)
 [![godoc](https://godoc.org/github.com/google/wire?status.svg)][godoc]
 
+> [!WARNING]
+> This project is no longer maintained.
+>
+> If you wish to update or extend wire, please do so in a fork.
 
 Wire is a code generation tool that automates connecting components using
 [dependency injection][]. Dependencies between components are represented in


### PR DESCRIPTION
Wire was archived by an automatic process because it was not being maintained. Unfortunately, it's true that there is no one maintaining wire, and we should make this clear in the README before re-archiving.